### PR TITLE
Fix line height for event titles.  Descenders were cut off.

### DIFF
--- a/www/css/app.css
+++ b/www/css/app.css
@@ -56,3 +56,5 @@ input[type="radio"]{display:none;}
 
 .et input[type="radio"] + label span {display:inline-block;width:91px;height:91px;background:url("../img/icons/etSprite.png") left top no-repeat;}
 .et input[type="radio"]:checked + label span {background: url("../img/icons/etSprite.png") -92px top no-repeat;}
+
+h2 {line-height: 20px;}


### PR DESCRIPTION
Ionic's styling was cutting off the descenders for the event titles, so I boosted the line-height in app.css.
